### PR TITLE
Remove unused local variable

### DIFF
--- a/include/arch/riscv/sel4runtime/thread_arch.h
+++ b/include/arch/riscv/sel4runtime/thread_arch.h
@@ -11,32 +11,36 @@
  */
 #include <stdint.h>
 
-static inline uintptr_t sel4runtime_read_tp(void) {
+static inline uintptr_t sel4runtime_read_tp(void)
+{
 #ifdef __clang__
     uintptr_t reg;
-    __asm__ __volatile__ ("or %0, tp, x0" : "=r" (reg) );
+    __asm__ __volatile__("or %0, tp, x0" : "=r"(reg));
 #else
     register uintptr_t reg __asm__("tp");
 #endif
     return reg;
 }
 
-static inline void sel4runtime_write_tp(uintptr_t reg) {
+static inline void sel4runtime_write_tp(uintptr_t reg)
+{
     uintptr_t tp;
-    __asm__ __volatile__ ("or tp, %0, x0" :: "r" (reg) );
+    __asm__ __volatile__("or tp, %0, x0" :: "r"(reg));
 }
 
 /*
  * Obtain the value of the TLS base for the current thread.
  */
-static inline uintptr_t sel4runtime_get_tls_base(void) {
+static inline uintptr_t sel4runtime_get_tls_base(void)
+{
     return sel4runtime_read_tp();
 }
 
 /*
  * Set the value of the TLS base for the current thread.
  */
-static inline void sel4runtime_set_tls_base(uintptr_t tls_base) {
+static inline void sel4runtime_set_tls_base(uintptr_t tls_base)
+{
     sel4runtime_write_tp(tls_base);
 }
 

--- a/include/arch/riscv/sel4runtime/thread_arch.h
+++ b/include/arch/riscv/sel4runtime/thread_arch.h
@@ -24,7 +24,6 @@ static inline uintptr_t sel4runtime_read_tp(void)
 
 static inline void sel4runtime_write_tp(uintptr_t reg)
 {
-    uintptr_t tp;
     __asm__ __volatile__("or tp, %0, x0" :: "r"(reg));
 }
 


### PR DESCRIPTION
Remove unused local variable to avoid compiler warning