### PR TITLE
Remove muslc dependencies from sel4runtim

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,4 +124,4 @@ add_dependencies(sel4runtime sel4runtime_crt)
 
 # A C library is still needed here to provide memcpy, stdint.h, and
 # elf.h
-target_link_libraries(sel4runtime PUBLIC sel4 muslc sel4_autoconf PRIVATE sel4runtime_Config)
+target_link_libraries(sel4runtime PUBLIC sel4 sel4_autoconf PRIVATE sel4runtime_Config)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,7 @@ list(
         src/init.c
         src/memset.c
         src/memcpy.c
+        src/vsyscall.c
 )
 if(("${KernelSel4Arch}" STREQUAL "aarch32") OR ("${KernelSel4Arch}" STREQUAL "arm_hyp"))
     list(

--- a/include/arch/riscv/sel4runtime/thread_arch.h
+++ b/include/arch/riscv/sel4runtime/thread_arch.h
@@ -9,20 +9,20 @@
  *
  * @TAG(DATA61_BSD)
  */
-#include <stdint.h>
+#include <sel4runtime/stdint.h>
 
-static inline uintptr_t sel4runtime_read_tp(void)
+static inline sel4runtime_uintptr_t sel4runtime_read_tp(void)
 {
 #ifdef __clang__
-    uintptr_t reg;
+    sel4runtime_uintptr_t reg;
     __asm__ __volatile__("or %0, tp, x0" : "=r"(reg));
 #else
-    register uintptr_t reg __asm__("tp");
+    register sel4runtime_uintptr_t reg __asm__("tp");
 #endif
     return reg;
 }
 
-static inline void sel4runtime_write_tp(uintptr_t reg)
+static inline void sel4runtime_write_tp(sel4runtime_uintptr_t reg)
 {
     __asm__ __volatile__("or tp, %0, x0" :: "r"(reg));
 }
@@ -30,7 +30,7 @@ static inline void sel4runtime_write_tp(uintptr_t reg)
 /*
  * Obtain the value of the TLS base for the current thread.
  */
-static inline uintptr_t sel4runtime_get_tls_base(void)
+static inline sel4runtime_uintptr_t sel4runtime_get_tls_base(void)
 {
     return sel4runtime_read_tp();
 }
@@ -38,7 +38,7 @@ static inline uintptr_t sel4runtime_get_tls_base(void)
 /*
  * Set the value of the TLS base for the current thread.
  */
-static inline void sel4runtime_set_tls_base(uintptr_t tls_base)
+static inline void sel4runtime_set_tls_base(sel4runtime_uintptr_t tls_base)
 {
     sel4runtime_write_tp(tls_base);
 }

--- a/include/mode/32/sel4runtime/mode/elf.h
+++ b/include/mode/32/sel4runtime/mode/elf.h
@@ -9,7 +9,7 @@
  *
  * @TAG(DATA61_BSD)
  */
-#include <elf.h>
+#include <sel4runtime/elf.h>
 #pragma once
 
 // The elf header is a different structure depending on the word size of

--- a/include/mode/64/sel4runtime/mode/elf.h
+++ b/include/mode/64/sel4runtime/mode/elf.h
@@ -9,7 +9,7 @@
  *
  * @TAG(DATA61_BSD)
  */
-#include <elf.h>
+#include <sel4runtime/elf.h>
 
 #pragma once
 

--- a/include/sel4_arch/aarch32/sel4runtime/thread_arch.h
+++ b/include/sel4_arch/aarch32/sel4runtime/thread_arch.h
@@ -11,26 +11,26 @@
  */
 #include <autoconf.h>
 #include <sel4/arch/constants.h>
-#include <stdint.h>
+#include <sel4runtime/stdint.h>
 
 #if ((__ARM_ARCH_6K__ || __ARM_ARCH_6ZK__) && !__thumb__) \
  || __ARM_ARCH_7A__ || __ARM_ARCH_7R__ || __ARM_ARCH >= 7
 
-static inline uintptr_t sel4runtime_read_tpidr_el0(void)
+static inline sel4runtime_uintptr_t sel4runtime_read_tpidr_el0(void)
 {
-    uintptr_t reg;
+    sel4runtime_uintptr_t reg;
     __asm__ __volatile__("mrc p15,0,%0,c13,c0,2" : "=r"(reg));
     return reg;
 }
 
-static inline void sel4runtime_write_tpidr_el0(uintptr_t reg)
+static inline void sel4runtime_write_tpidr_el0(sel4runtime_uintptr_t reg)
 {
     __asm__ __volatile__("mcr p15,0,%0,c13,c0,2" :: "r"(reg));
 }
 
-static inline uintptr_t sel4runtime_read_tpidrro_el0(void)
+static inline sel4runtime_uintptr_t sel4runtime_read_tpidrro_el0(void)
 {
-    uintptr_t reg;
+    sel4runtime_uintptr_t reg;
     __asm__ __volatile__("mrc p15,0,%0,c13,c0,3" : "=r"(reg));
     return reg;
 }
@@ -38,7 +38,7 @@ static inline uintptr_t sel4runtime_read_tpidrro_el0(void)
 /*
  * Set the value of the TLS base for the current thread.
  */
-static inline void sel4runtime_set_tls_base(uintptr_t tls_base)
+static inline void sel4runtime_set_tls_base(sel4runtime_uintptr_t tls_base)
 {
     sel4runtime_write_tpidr_el0(tls_base);
 }
@@ -53,23 +53,23 @@ static inline void sel4runtime_set_tls_base(uintptr_t tls_base)
  * spaces. The IPC buffer and thread pointer occupy the first two words
  * in this frame respectively.
  */
-static inline uintptr_t sel4runtime_read_tpidr_el0(void)
+static inline sel4runtime_uintptr_t sel4runtime_read_tpidr_el0(void)
 {
     void **globals_frame = (void **)seL4_GlobalsFrame;
-    return (uintptr_t)globals_frame[0];
+    return (sel4runtime_uintptr_t)globals_frame[0];
 }
 
-static inline uintptr_t sel4runtime_read_tpidrro_el0(void)
+static inline sel4runtime_uintptr_t sel4runtime_read_tpidrro_el0(void)
 {
     void **globals_frame = (void **)seL4_GlobalsFrame;
-    return (uintptr_t)globals_frame[1];
+    return (sel4runtime_uintptr_t)globals_frame[1];
 }
 
 #ifdef CONFIG_SET_TLS_BASE_SELF
 /*
  * Set the value of the TLS base for the current thread.
  */
-static inline void sel4runtime_set_tls_base(uintptr_t tls_base)
+static inline void sel4runtime_set_tls_base(sel4runtime_uintptr_t tls_base)
 {
     seL4_SetTLSBase(tls_base);
 }
@@ -81,7 +81,7 @@ static inline void sel4runtime_set_tls_base(uintptr_t tls_base)
 /*
  * Obtain the value of the TLS base for the current thread.
  */
-static inline uintptr_t sel4runtime_get_tls_base(void)
+static inline sel4runtime_uintptr_t sel4runtime_get_tls_base(void)
 {
     return sel4runtime_read_tpidr_el0();
 }

--- a/include/sel4_arch/aarch64/sel4runtime/thread_arch.h
+++ b/include/sel4_arch/aarch64/sel4runtime/thread_arch.h
@@ -14,33 +14,38 @@
 /*
  * Obtain the value of the TLS base for the current thread.
  */
-static inline sel4runtime_uintptr_t sel4runtime_read_tpidr_el0(void) {
+static inline sel4runtime_uintptr_t sel4runtime_read_tpidr_el0(void)
+{
     sel4runtime_uintptr_t reg;
-    __asm__ __volatile__ ("mrs %0,tpidr_el0" : "=r"(reg));
+    __asm__ __volatile__("mrs %0,tpidr_el0" : "=r"(reg));
     return reg;
 }
 
-static inline void sel4runtime_write_tpidr_el0(sel4runtime_uintptr_t reg) {
-    __asm__ __volatile__ ("msr tpidr_el0,%0" :: "r"(reg));
+static inline void sel4runtime_write_tpidr_el0(sel4runtime_uintptr_t reg)
+{
+    __asm__ __volatile__("msr tpidr_el0,%0" :: "r"(reg));
 }
 
-static inline sel4runtime_uintptr_t sel4runtime_read_tpidrro_el0(void) {
+static inline sel4runtime_uintptr_t sel4runtime_read_tpidrro_el0(void)
+{
     sel4runtime_uintptr_t reg;
-    __asm__ __volatile__ ("mrs %0,tpidrro_el0" : "=r"(reg));
+    __asm__ __volatile__("mrs %0,tpidrro_el0" : "=r"(reg));
     return reg;
 }
 
 /*
  * Obtain the value of the TLS base for the current thread.
  */
-static inline sel4runtime_uintptr_t sel4runtime_get_tls_base(void) {
+static inline sel4runtime_uintptr_t sel4runtime_get_tls_base(void)
+{
     return sel4runtime_read_tpidr_el0();
 }
 
 /*
  * Set the value of the TLS base for the current thread.
  */
-static inline void sel4runtime_set_tls_base(sel4runtime_uintptr_t tls_base) {
+static inline void sel4runtime_set_tls_base(sel4runtime_uintptr_t tls_base)
+{
     sel4runtime_write_tpidr_el0(tls_base);
 }
 

--- a/include/sel4_arch/aarch64/sel4runtime/thread_arch.h
+++ b/include/sel4_arch/aarch64/sel4runtime/thread_arch.h
@@ -9,23 +9,23 @@
  *
  * @TAG(DATA61_BSD)
  */
-#include <stdint.h>
+#include <sel4runtime/stdint.h>
 
 /*
  * Obtain the value of the TLS base for the current thread.
  */
-static inline uintptr_t sel4runtime_read_tpidr_el0(void) {
-    uintptr_t reg;
+static inline sel4runtime_uintptr_t sel4runtime_read_tpidr_el0(void) {
+    sel4runtime_uintptr_t reg;
     __asm__ __volatile__ ("mrs %0,tpidr_el0" : "=r"(reg));
     return reg;
 }
 
-static inline void sel4runtime_write_tpidr_el0(uintptr_t reg) {
+static inline void sel4runtime_write_tpidr_el0(sel4runtime_uintptr_t reg) {
     __asm__ __volatile__ ("msr tpidr_el0,%0" :: "r"(reg));
 }
 
-static inline uintptr_t sel4runtime_read_tpidrro_el0(void) {
-    uintptr_t reg;
+static inline sel4runtime_uintptr_t sel4runtime_read_tpidrro_el0(void) {
+    sel4runtime_uintptr_t reg;
     __asm__ __volatile__ ("mrs %0,tpidrro_el0" : "=r"(reg));
     return reg;
 }
@@ -33,14 +33,14 @@ static inline uintptr_t sel4runtime_read_tpidrro_el0(void) {
 /*
  * Obtain the value of the TLS base for the current thread.
  */
-static inline uintptr_t sel4runtime_get_tls_base(void) {
+static inline sel4runtime_uintptr_t sel4runtime_get_tls_base(void) {
     return sel4runtime_read_tpidr_el0();
 }
 
 /*
  * Set the value of the TLS base for the current thread.
  */
-static inline void sel4runtime_set_tls_base(uintptr_t tls_base) {
+static inline void sel4runtime_set_tls_base(sel4runtime_uintptr_t tls_base) {
     sel4runtime_write_tpidr_el0(tls_base);
 }
 

--- a/include/sel4_arch/ia32/sel4runtime/thread_arch.h
+++ b/include/sel4_arch/ia32/sel4runtime/thread_arch.h
@@ -10,14 +10,14 @@
  * @TAG(DATA61_BSD)
  */
 #include <autoconf.h>
-#include <stdint.h>
+#include <sel4runtime/stdint.h>
 
 /*
  * Obtain the value of the TLS base for the current thread.
  */
-static inline uintptr_t sel4runtime_get_tls_base(void)
+static inline sel4runtime_uintptr_t sel4runtime_get_tls_base(void)
 {
-    uintptr_t tp;
+    sel4runtime_uintptr_t tp;
     __asm__ __volatile__("movl %%gs:0,%0" : "=r"(tp));
     return tp;
 }
@@ -26,7 +26,7 @@ static inline uintptr_t sel4runtime_get_tls_base(void)
 /*
  * Set the value of the TLS base for the current thread.
  */
-static inline void sel4runtime_set_tls_base(uintptr_t tls_base)
+static inline void sel4runtime_set_tls_base(sel4runtime_uintptr_t tls_base)
 {
     seL4_SetTLSBase(tls_base);
 }

--- a/include/sel4_arch/x86_64/sel4runtime/thread_arch.h
+++ b/include/sel4_arch/x86_64/sel4runtime/thread_arch.h
@@ -10,29 +10,29 @@
  * @TAG(DATA61_BSD)
  */
 #include <autoconf.h>
-#include <stdint.h>
+#include <sel4runtime/stdint.h>
 
 #ifdef CONFIG_FSGSBASE_INST
-static inline uintptr_t sel4runtime_read_fs_base(void)
+static inline sel4runtime_uintptr_t sel4runtime_read_fs_base(void)
 {
-    uintptr_t reg;
+    sel4runtime_uintptr_t reg;
     __asm__ __volatile__("rdfsbase %0" : "=r"(reg));
     return reg;
 }
 
-static inline void sel4runtime_write_fs_base(uintptr_t reg)
+static inline void sel4runtime_write_fs_base(sel4runtime_uintptr_t reg)
 {
     __asm__ __volatile__("wrfsbase %0" :: "r"(reg));
 }
 
-static inline uintptr_t sel4runtime_read_gs_base(void)
+static inline sel4runtime_uintptr_t sel4runtime_read_gs_base(void)
 {
-    uintptr_t reg;
+    sel4runtime_uintptr_t reg;
     __asm__ __volatile__("rdgsbase %0" : "=r"(reg));
     return reg;
 }
 
-static inline void sel4runtime_write_gs_base(uintptr_t reg)
+static inline void sel4runtime_write_gs_base(sel4runtime_uintptr_t reg)
 {
     __asm__ __volatile__("wrgsbase %0" :: "r"(reg));
 }
@@ -40,7 +40,7 @@ static inline void sel4runtime_write_gs_base(uintptr_t reg)
 /*
  * Obtain the value of the TLS base for the current thread.
  */
-static inline uintptr_t sel4runtime_get_tls_base(void)
+static inline sel4runtime_uintptr_t sel4runtime_get_tls_base(void)
 {
     return sel4runtime_read_fs_base();
 }
@@ -48,7 +48,7 @@ static inline uintptr_t sel4runtime_get_tls_base(void)
 /*
  * Set the value of the TLS base for the current thread.
  */
-static inline void sel4runtime_set_tls_base(uintptr_t tls_base)
+static inline void sel4runtime_set_tls_base(sel4runtime_uintptr_t tls_base)
 {
     sel4runtime_write_fs_base(tls_base);
 }
@@ -58,9 +58,9 @@ static inline void sel4runtime_set_tls_base(uintptr_t tls_base)
 /*
  * Obtain the value of the TLS base for the current thread.
  */
-static inline uintptr_t sel4runtime_get_tls_base(void)
+static inline sel4runtime_uintptr_t sel4runtime_get_tls_base(void)
 {
-    uintptr_t tp;
+    sel4runtime_uintptr_t tp;
     __asm__ __volatile__("mov %%fs:0,%0" : "=r"(tp));
     return tp;
 }
@@ -69,7 +69,7 @@ static inline uintptr_t sel4runtime_get_tls_base(void)
 /*
  * Set the value of the TLS base for the current thread.
  */
-static inline void sel4runtime_set_tls_base(uintptr_t tls_base)
+static inline void sel4runtime_set_tls_base(sel4runtime_uintptr_t tls_base)
 {
     seL4_SetTLSBase(tls_base);
 }

--- a/include/sel4runtime.h
+++ b/include/sel4runtime.h
@@ -14,8 +14,8 @@
  *
  * This provides an interface to the values managed by sel4runtime.
  */
-#include <stddef.h>
-#include <stdint.h>
+#include <sel4runtime/stddef.h>
+#include <sel4runtime/stdint.h>
 #include <sel4/sel4.h>
 #include <sel4runtime/thread.h>
 #include <sel4runtime/auxv.h>
@@ -52,12 +52,12 @@ auxv_t const *sel4runtime_auxv(void);
 /*
  * Get the address of the TLS base register.
  */
-static inline uintptr_t sel4runtime_get_tls_base(void);
+static inline sel4runtime_uintptr_t sel4runtime_get_tls_base(void);
 
 /*
  * Set the address of the TLS base register.
  */
-static inline void sel4runtime_set_tls_base(uintptr_t tls_base);
+static inline void sel4runtime_set_tls_base(sel4runtime_uintptr_t tls_base);
 
 /*
  * Get the bootinfo pointer if the process was provided a bootinfo
@@ -68,13 +68,13 @@ seL4_BootInfo *sel4runtime_bootinfo(void);
 /*
  * Get the size in bytes needed to store the thread's TLS.
  */
-size_t sel4runtime_get_tls_size(void);
+sel4runtime_size_t sel4runtime_get_tls_size(void);
 
 /*
  * Get the offset used to calculate the thread pointer from the
  * starting address of the thread area.
  */
-size_t sel4runtime_get_tp_offset(void);
+sel4runtime_size_t sel4runtime_get_tp_offset(void);
 
 /*
  * Check if the TLS for the initial thread is enabled.
@@ -93,7 +93,7 @@ int sel4runtime_initial_tls_enabled(void);
  * @returns the pointer to the TLS that should be used to call
  *          seL4_TCB_SetTLSBase or NULL on error.
  */
-uintptr_t sel4runtime_write_tls_image(void *tls_memory);
+sel4runtime_uintptr_t sel4runtime_write_tls_image(void *tls_memory);
 
 /*
  * Move the TLS for the current thread into a new memory location.
@@ -109,7 +109,7 @@ uintptr_t sel4runtime_write_tls_image(void *tls_memory);
  * @returns the pointer to the TLS that should be used to call
  *          seL4_TCB_SetTLSBase.
  */
-uintptr_t sel4runtime_move_initial_tls(void *tls_memory);
+sel4runtime_uintptr_t sel4runtime_move_initial_tls(void *tls_memory);
 
 /*
  * Writes into a thread_local variable of another thread.
@@ -136,10 +136,10 @@ uintptr_t sel4runtime_move_initial_tls(void *tls_memory);
  * This assumes that TLS has been initialised for the current thread.
  */
 int __sel4runtime_write_tls_variable(
-    uintptr_t dest_tls_base,
+    sel4runtime_uintptr_t dest_tls_base,
     unsigned char *local_tls_dest,
     unsigned char *src,
-    size_t bytes
+    sel4runtime_size_t bytes
 );
 
 /*

--- a/include/sel4runtime/auxv.h
+++ b/include/sel4runtime/auxv.h
@@ -11,6 +11,17 @@
  */
 #pragma once
 
+// Standard auciliary vector values
+#define AT_NULL      0
+#define PT_LOAD      1
+#define PT_DYNAMIC   2
+#define AT_PHDR      3
+#define AT_PHENT     4
+#define AT_PHNUM     5
+#define PT_TLS       7
+#define PT_NUM       8
+#define AT_SYSINFO  32
+
 // seL4-specific auxiliary vector values.
 #define AT_SEL4_BOOT_INFO         64
 #define AT_SEL4_CSPACE_DESCRIPTOR 65

--- a/include/sel4runtime/elf.h
+++ b/include/sel4runtime/elf.h
@@ -1,0 +1,78 @@
+/*
+ * @TAG(OTHER_MIT)
+ */
+/*
+ * Copyright © 2005-2014 Rich Felker, et al.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#pragma once
+
+#include <sel4runtime/stdint.h>
+
+/*
+ * This is a minimal definition of the ELF headers that is sufficient
+ * for sel4runtime to pass through program headers.
+ */
+
+typedef sel4runtime_uint16_t Elf32_Half;
+typedef sel4runtime_uint16_t Elf64_Half;
+
+typedef sel4runtime_uint32_t Elf32_Word;
+typedef sel4runtime_int32_t  Elf32_Sword;
+typedef sel4runtime_uint32_t Elf64_Word;
+typedef sel4runtime_int32_t  Elf64_Sword;
+
+typedef sel4runtime_uint64_t Elf32_Xword;
+typedef sel4runtime_int64_t  Elf32_Sxword;
+typedef sel4runtime_uint64_t Elf64_Xword;
+typedef sel4runtime_int64_t  Elf64_Sxword;
+
+typedef sel4runtime_uint32_t Elf32_Addr;
+typedef sel4runtime_uint64_t Elf64_Addr;
+
+typedef sel4runtime_uint32_t Elf32_Off;
+typedef sel4runtime_uint64_t Elf64_Off;
+
+typedef sel4runtime_uint16_t Elf32_Section;
+typedef sel4runtime_uint16_t Elf64_Section;
+
+typedef struct {
+    Elf32_Word  p_type;
+    Elf32_Off   p_offset;
+    Elf32_Addr  p_vaddr;
+    Elf32_Addr  p_paddr;
+    Elf32_Word  p_filesz;
+    Elf32_Word  p_memsz;
+    Elf32_Word  p_flags;
+    Elf32_Word  p_align;
+} Elf32_Phdr;
+
+typedef struct {
+    Elf64_Word   p_type;
+    Elf64_Word   p_flags;
+    Elf64_Off    p_offset;
+    Elf64_Addr   p_vaddr;
+    Elf64_Addr   p_paddr;
+    Elf64_Xword  p_filesz;
+    Elf64_Xword  p_memsz;
+    Elf64_Xword  p_align;
+} Elf64_Phdr;

--- a/include/sel4runtime/start.h
+++ b/include/sel4runtime/start.h
@@ -12,7 +12,7 @@
 #pragma once
 
 #include <sel4runtime/auxv.h>
-#include <elf.h>
+#include <sel4runtime/elf.h>
 #include <sel4runtime/mode/elf.h>
 
 // Entry into C program.

--- a/include/sel4runtime/stddef.h
+++ b/include/sel4runtime/stddef.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2020, Data61
+ * Commonwealth Scientific and Industrial Research Organisation (CSIRO)
+ * ABN 41 687 119 230.
+ *
+ * This software may be distributed and modified according to the terms of
+ * the BSD 2-Clause license. Note that NO WARRANTY is provided.
+ * See "LICENSE_BSD2.txt" for details.
+ *
+ * @TAG(DATA61_BSD)
+ */
+
+#include <sel4runtime/stdint.h>
+
+#pragma once
+
+/*
+ * This is a very naive implementation of stddef that should work for
+ * most major platforms. This is the minimal subset needed for the
+ * runtime.
+ */
+
+typedef sel4runtime_uintptr_t sel4runtime_size_t;
+
+#define SEL4RUNTIME_NULL ((void *)0)

--- a/include/sel4runtime/stdint.h
+++ b/include/sel4runtime/stdint.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020, Data61
+ * Commonwealth Scientific and Industrial Research Organisation (CSIRO)
+ * ABN 41 687 119 230.
+ *
+ * This software may be distributed and modified according to the terms of
+ * the BSD 2-Clause license. Note that NO WARRANTY is provided.
+ * See "LICENSE_BSD2.txt" for details.
+ *
+ * @TAG(DATA61_BSD)
+ */
+
+#pragma once
+
+/*
+ * This is a very naive implementation of stdint that should work for
+ * most major platforms. This is the minimal subset needed for the
+ * runtime.
+ */
+
+_Static_assert(sizeof(char)      == 1, "char is 8 bits");
+_Static_assert(sizeof(short)     == 2, "short is 16 bits");
+_Static_assert(sizeof(int)       == 4, "int is 32 bits");
+_Static_assert(sizeof(long long) == 8, "long long is 64 bits");
+_Static_assert(sizeof(long)      == sizeof(void *), "long is word size");
+
+/* Fixed size integer types */
+typedef signed char      sel4runtime_int8_t;
+typedef signed short     sel4runtime_int16_t;
+typedef signed int       sel4runtime_int32_t;
+typedef signed long long sel4runtime_int64_t;
+
+typedef unsigned char      sel4runtime_uint8_t;
+typedef unsigned short     sel4runtime_uint16_t;
+typedef unsigned int       sel4runtime_uint32_t;
+typedef unsigned long long sel4runtime_uint64_t;
+
+/* Word-sized integer types */
+typedef signed long   sel4runtime_intptr_t;
+typedef unsigned long sel4runtime_uintptr_t;

--- a/src/crt1.c
+++ b/src/crt1.c
@@ -38,7 +38,7 @@ void __sel4_start_c(void const *stack)
     // The environment pointer vector follows after the argv.
     char const *const *envp = &argv[argc + 1];
     int envc = 0;
-    while (envp[envc] != NULL) {
+    while (envp[envc] != SEL4RUNTIME_NULL) {
         envc++;
     }
 

--- a/src/env.c
+++ b/src/env.c
@@ -24,9 +24,6 @@
 #define MIN_ALIGN_BYTES 16
 #define MIN_ALIGNED __attribute__((aligned (MIN_ALIGN_BYTES)))
 
-// Global vsyscall handler (defined in musllibc)
-extern sel4runtime_size_t __sysinfo;
-
 // Static TLS for initial thread.
 static char static_tls[CONFIG_SEL4RUNTIME_STATIC_TLS] MIN_ALIGNED = {};
 
@@ -302,10 +299,6 @@ static void parse_auxv(auxv_t const auxv[])
         }
         case AT_PHDR: {
             env.program_header.headers = auxv[i].a_un.a_ptr;
-            break;
-        }
-        case AT_SYSINFO: {
-            __sysinfo = (sel4runtime_size_t)(auxv[i].a_un.a_ptr);
             break;
         }
         case AT_SEL4_BOOT_INFO: {

--- a/src/init.c
+++ b/src/init.c
@@ -31,26 +31,28 @@ void _fini(void);
 extern routine __fini_array_start[];
 extern routine __fini_array_end[];
 
-void __sel4runtime_run_constructors(void) {
+void __sel4runtime_run_constructors(void)
+{
     int preinit_array_len
         = &__preinit_array_end[0]
-        - &__preinit_array_start[0];
+          - &__preinit_array_start[0];
     for (int f = 0; f < preinit_array_len; f++) {
         __preinit_array_start[f]();
     }
     _init();
     int init_array_len
         = &__init_array_end[0]
-        - &__init_array_start[0];
+          - &__init_array_start[0];
     for (int f = 0; f < init_array_len; f++) {
         __init_array_start[f]();
     }
 }
 
-void __sel4runtime_run_destructors(void) {
+void __sel4runtime_run_destructors(void)
+{
     int fini_array_len
         = &__fini_array_end[0]
-        - &__fini_array_start[0];
+          - &__fini_array_start[0];
     for (int f = fini_array_len - 1; f >= 0; f--) {
         __fini_array_start[f]();
     }

--- a/src/memcpy.c
+++ b/src/memcpy.c
@@ -26,7 +26,7 @@
 
 #include "util.h"
 
-void *__sel4runtime_memcpy(void *restrict dest, const void *restrict src, size_t n)
+void *__sel4runtime_memcpy(void *restrict dest, const void *restrict src, sel4runtime_size_t n)
 {
 	unsigned char *d = dest;
 	const unsigned char *s = src;
@@ -41,12 +41,12 @@ void *__sel4runtime_memcpy(void *restrict dest, const void *restrict src, size_t
 #define RS >>
 #endif
 
-	typedef uint32_t __attribute__((__may_alias__)) u32;
-	uint32_t w, x;
+	typedef sel4runtime_uint32_t __attribute__((__may_alias__)) u32;
+	sel4runtime_uint32_t w, x;
 
-	for (; (uintptr_t)s % 4 && n; n--) *d++ = *s++;
+	for (; (sel4runtime_uintptr_t)s % 4 && n; n--) *d++ = *s++;
 
-	if ((uintptr_t)d % 4 == 0) {
+	if ((sel4runtime_uintptr_t)d % 4 == 0) {
 		for (; n>=16; s+=16, d+=16, n-=16) {
 			*(u32 *)(d+0) = *(u32 *)(s+0);
 			*(u32 *)(d+4) = *(u32 *)(s+4);
@@ -71,7 +71,7 @@ void *__sel4runtime_memcpy(void *restrict dest, const void *restrict src, size_t
 		return dest;
 	}
 
-	if (n >= 32) switch ((uintptr_t)d % 4) {
+	if (n >= 32) switch ((sel4runtime_uintptr_t)d % 4) {
 	case 1:
 		w = *(u32 *)s;
 		*d++ = *s++;

--- a/src/memcpy.c
+++ b/src/memcpy.c
@@ -28,8 +28,8 @@
 
 void *__sel4runtime_memcpy(void *restrict dest, const void *restrict src, sel4runtime_size_t n)
 {
-	unsigned char *d = dest;
-	const unsigned char *s = src;
+    unsigned char *d = dest;
+    const unsigned char *s = src;
 
 #ifdef __GNUC__
 
@@ -41,108 +41,137 @@ void *__sel4runtime_memcpy(void *restrict dest, const void *restrict src, sel4ru
 #define RS >>
 #endif
 
-	typedef sel4runtime_uint32_t __attribute__((__may_alias__)) u32;
-	sel4runtime_uint32_t w, x;
+    typedef sel4runtime_uint32_t __attribute__((__may_alias__)) u32;
+    sel4runtime_uint32_t w, x;
 
-	for (; (sel4runtime_uintptr_t)s % 4 && n; n--) *d++ = *s++;
+    for (; (sel4runtime_uintptr_t)s % 4 && n; n--) {
+        *d++ = *s++;
+    }
 
-	if ((sel4runtime_uintptr_t)d % 4 == 0) {
-		for (; n>=16; s+=16, d+=16, n-=16) {
-			*(u32 *)(d+0) = *(u32 *)(s+0);
-			*(u32 *)(d+4) = *(u32 *)(s+4);
-			*(u32 *)(d+8) = *(u32 *)(s+8);
-			*(u32 *)(d+12) = *(u32 *)(s+12);
-		}
-		if (n&8) {
-			*(u32 *)(d+0) = *(u32 *)(s+0);
-			*(u32 *)(d+4) = *(u32 *)(s+4);
-			d += 8; s += 8;
-		}
-		if (n&4) {
-			*(u32 *)(d+0) = *(u32 *)(s+0);
-			d += 4; s += 4;
-		}
-		if (n&2) {
-			*d++ = *s++; *d++ = *s++;
-		}
-		if (n&1) {
-			*d = *s;
-		}
-		return dest;
-	}
+    if ((sel4runtime_uintptr_t)d % 4 == 0) {
+        for (; n >= 16; s += 16, d += 16, n -= 16) {
+            *(u32 *)(d + 0) = *(u32 *)(s + 0);
+            *(u32 *)(d + 4) = *(u32 *)(s + 4);
+            *(u32 *)(d + 8) = *(u32 *)(s + 8);
+            *(u32 *)(d + 12) = *(u32 *)(s + 12);
+        }
+        if (n & 8) {
+            *(u32 *)(d + 0) = *(u32 *)(s + 0);
+            *(u32 *)(d + 4) = *(u32 *)(s + 4);
+            d += 8;
+            s += 8;
+        }
+        if (n & 4) {
+            *(u32 *)(d + 0) = *(u32 *)(s + 0);
+            d += 4;
+            s += 4;
+        }
+        if (n & 2) {
+            *d++ = *s++;
+            *d++ = *s++;
+        }
+        if (n & 1) {
+            *d = *s;
+        }
+        return dest;
+    }
 
-	if (n >= 32) switch ((sel4runtime_uintptr_t)d % 4) {
-	case 1:
-		w = *(u32 *)s;
-		*d++ = *s++;
-		*d++ = *s++;
-		*d++ = *s++;
-		n -= 3;
-		for (; n>=17; s+=16, d+=16, n-=16) {
-			x = *(u32 *)(s+1);
-			*(u32 *)(d+0) = (w LS 24) | (x RS 8);
-			w = *(u32 *)(s+5);
-			*(u32 *)(d+4) = (x LS 24) | (w RS 8);
-			x = *(u32 *)(s+9);
-			*(u32 *)(d+8) = (w LS 24) | (x RS 8);
-			w = *(u32 *)(s+13);
-			*(u32 *)(d+12) = (x LS 24) | (w RS 8);
-		}
-		break;
-	case 2:
-		w = *(u32 *)s;
-		*d++ = *s++;
-		*d++ = *s++;
-		n -= 2;
-		for (; n>=18; s+=16, d+=16, n-=16) {
-			x = *(u32 *)(s+2);
-			*(u32 *)(d+0) = (w LS 16) | (x RS 16);
-			w = *(u32 *)(s+6);
-			*(u32 *)(d+4) = (x LS 16) | (w RS 16);
-			x = *(u32 *)(s+10);
-			*(u32 *)(d+8) = (w LS 16) | (x RS 16);
-			w = *(u32 *)(s+14);
-			*(u32 *)(d+12) = (x LS 16) | (w RS 16);
-		}
-		break;
-	case 3:
-		w = *(u32 *)s;
-		*d++ = *s++;
-		n -= 1;
-		for (; n>=19; s+=16, d+=16, n-=16) {
-			x = *(u32 *)(s+3);
-			*(u32 *)(d+0) = (w LS 8) | (x RS 24);
-			w = *(u32 *)(s+7);
-			*(u32 *)(d+4) = (x LS 8) | (w RS 24);
-			x = *(u32 *)(s+11);
-			*(u32 *)(d+8) = (w LS 8) | (x RS 24);
-			w = *(u32 *)(s+15);
-			*(u32 *)(d+12) = (x LS 8) | (w RS 24);
-		}
-		break;
-	}
-	if (n&16) {
-		*d++ = *s++; *d++ = *s++; *d++ = *s++; *d++ = *s++;
-		*d++ = *s++; *d++ = *s++; *d++ = *s++; *d++ = *s++;
-		*d++ = *s++; *d++ = *s++; *d++ = *s++; *d++ = *s++;
-		*d++ = *s++; *d++ = *s++; *d++ = *s++; *d++ = *s++;
-	}
-	if (n&8) {
-		*d++ = *s++; *d++ = *s++; *d++ = *s++; *d++ = *s++;
-		*d++ = *s++; *d++ = *s++; *d++ = *s++; *d++ = *s++;
-	}
-	if (n&4) {
-		*d++ = *s++; *d++ = *s++; *d++ = *s++; *d++ = *s++;
-	}
-	if (n&2) {
-		*d++ = *s++; *d++ = *s++;
-	}
-	if (n&1) {
-		*d = *s;
-	}
-	return dest;
+    if (n >= 32) switch ((sel4runtime_uintptr_t)d % 4) {
+        case 1:
+            w = *(u32 *)s;
+            *d++ = *s++;
+            *d++ = *s++;
+            *d++ = *s++;
+            n -= 3;
+            for (; n >= 17; s += 16, d += 16, n -= 16) {
+                x = *(u32 *)(s + 1);
+                *(u32 *)(d + 0) = (w LS 24) | (x RS 8);
+                w = *(u32 *)(s + 5);
+                *(u32 *)(d + 4) = (x LS 24) | (w RS 8);
+                x = *(u32 *)(s + 9);
+                *(u32 *)(d + 8) = (w LS 24) | (x RS 8);
+                w = *(u32 *)(s + 13);
+                *(u32 *)(d + 12) = (x LS 24) | (w RS 8);
+            }
+            break;
+        case 2:
+            w = *(u32 *)s;
+            *d++ = *s++;
+            *d++ = *s++;
+            n -= 2;
+            for (; n >= 18; s += 16, d += 16, n -= 16) {
+                x = *(u32 *)(s + 2);
+                *(u32 *)(d + 0) = (w LS 16) | (x RS 16);
+                w = *(u32 *)(s + 6);
+                *(u32 *)(d + 4) = (x LS 16) | (w RS 16);
+                x = *(u32 *)(s + 10);
+                *(u32 *)(d + 8) = (w LS 16) | (x RS 16);
+                w = *(u32 *)(s + 14);
+                *(u32 *)(d + 12) = (x LS 16) | (w RS 16);
+            }
+            break;
+        case 3:
+            w = *(u32 *)s;
+            *d++ = *s++;
+            n -= 1;
+            for (; n >= 19; s += 16, d += 16, n -= 16) {
+                x = *(u32 *)(s + 3);
+                *(u32 *)(d + 0) = (w LS 8) | (x RS 24);
+                w = *(u32 *)(s + 7);
+                *(u32 *)(d + 4) = (x LS 8) | (w RS 24);
+                x = *(u32 *)(s + 11);
+                *(u32 *)(d + 8) = (w LS 8) | (x RS 24);
+                w = *(u32 *)(s + 15);
+                *(u32 *)(d + 12) = (x LS 8) | (w RS 24);
+            }
+            break;
+        }
+    if (n & 16) {
+        *d++ = *s++;
+        *d++ = *s++;
+        *d++ = *s++;
+        *d++ = *s++;
+        *d++ = *s++;
+        *d++ = *s++;
+        *d++ = *s++;
+        *d++ = *s++;
+        *d++ = *s++;
+        *d++ = *s++;
+        *d++ = *s++;
+        *d++ = *s++;
+        *d++ = *s++;
+        *d++ = *s++;
+        *d++ = *s++;
+        *d++ = *s++;
+    }
+    if (n & 8) {
+        *d++ = *s++;
+        *d++ = *s++;
+        *d++ = *s++;
+        *d++ = *s++;
+        *d++ = *s++;
+        *d++ = *s++;
+        *d++ = *s++;
+        *d++ = *s++;
+    }
+    if (n & 4) {
+        *d++ = *s++;
+        *d++ = *s++;
+        *d++ = *s++;
+        *d++ = *s++;
+    }
+    if (n & 2) {
+        *d++ = *s++;
+        *d++ = *s++;
+    }
+    if (n & 1) {
+        *d = *s;
+    }
+    return dest;
 #endif
 
-	for (; n; n--) *d++ = *s++;
-	return dest;
+    for (; n; n--) {
+        *d++ = *s++;
+    }
+    return dest;
 }

--- a/src/memset.c
+++ b/src/memset.c
@@ -26,10 +26,10 @@
 
 #include "util.h"
 
-void *__sel4runtime_memset(void *dest, int c, size_t n)
+void *__sel4runtime_memset(void *dest, int c, sel4runtime_size_t n)
 {
 	unsigned char *s = dest;
-	size_t k;
+	sel4runtime_size_t k;
 
 	/* Fill head and tail with minimal branching. Each
 	 * conditional ensures that all the subsequently used
@@ -49,14 +49,14 @@ void *__sel4runtime_memset(void *dest, int c, size_t n)
 	 * already took care of any head/tail that get cut off
 	 * by the alignment. */
 
-	k = -(uintptr_t)s & 3;
+	k = -(sel4runtime_uintptr_t)s & 3;
 	s += k;
 	n -= k;
 	n &= -4;
 
 #ifdef __GNUC__
-	typedef uint32_t __attribute__((__may_alias__)) u32;
-	typedef uint64_t __attribute__((__may_alias__)) u64;
+	typedef sel4runtime_uint32_t __attribute__((__may_alias__)) u32;
+	typedef sel4runtime_uint64_t __attribute__((__may_alias__)) u64;
 
 	u32 c32 = ((u32)-1)/255 * (unsigned char)c;
 
@@ -87,7 +87,7 @@ void *__sel4runtime_memset(void *dest, int c, size_t n)
 	 * and avoid writing the same bytes twice as much as is
 	 * practical without introducing additional branching. */
 
-	k = 24 + ((uintptr_t)s & 4);
+	k = 24 + ((sel4runtime_uintptr_t)s & 4);
 	s += k;
 	n -= k;
 

--- a/src/memset.c
+++ b/src/memset.c
@@ -28,84 +28,98 @@
 
 void *__sel4runtime_memset(void *dest, int c, sel4runtime_size_t n)
 {
-	unsigned char *s = dest;
-	sel4runtime_size_t k;
+    unsigned char *s = dest;
+    sel4runtime_size_t k;
 
-	/* Fill head and tail with minimal branching. Each
-	 * conditional ensures that all the subsequently used
-	 * offsets are well-defined and in the dest region. */
+    /* Fill head and tail with minimal branching. Each
+     * conditional ensures that all the subsequently used
+     * offsets are well-defined and in the dest region. */
 
-	if (!n) return dest;
-	s[0] = s[n-1] = c;
-	if (n <= 2) return dest;
-	s[1] = s[n-2] = c;
-	s[2] = s[n-3] = c;
-	if (n <= 6) return dest;
-	s[3] = s[n-4] = c;
-	if (n <= 8) return dest;
+    if (!n) {
+        return dest;
+    }
+    s[0] = s[n - 1] = c;
+    if (n <= 2) {
+        return dest;
+    }
+    s[1] = s[n - 2] = c;
+    s[2] = s[n - 3] = c;
+    if (n <= 6) {
+        return dest;
+    }
+    s[3] = s[n - 4] = c;
+    if (n <= 8) {
+        return dest;
+    }
 
-	/* Advance pointer to align it at a 4-byte boundary,
-	 * and truncate n to a multiple of 4. The previous code
-	 * already took care of any head/tail that get cut off
-	 * by the alignment. */
+    /* Advance pointer to align it at a 4-byte boundary,
+     * and truncate n to a multiple of 4. The previous code
+     * already took care of any head/tail that get cut off
+     * by the alignment. */
 
-	k = -(sel4runtime_uintptr_t)s & 3;
-	s += k;
-	n -= k;
-	n &= -4;
+    k = -(sel4runtime_uintptr_t)s & 3;
+    s += k;
+    n -= k;
+    n &= -4;
 
 #ifdef __GNUC__
-	typedef sel4runtime_uint32_t __attribute__((__may_alias__)) u32;
-	typedef sel4runtime_uint64_t __attribute__((__may_alias__)) u64;
+    typedef sel4runtime_uint32_t __attribute__((__may_alias__)) u32;
+    typedef sel4runtime_uint64_t __attribute__((__may_alias__)) u64;
 
-	u32 c32 = ((u32)-1)/255 * (unsigned char)c;
+    u32 c32 = ((u32) - 1) / 255 * (unsigned char)c;
 
-	/* In preparation to copy 32 bytes at a time, aligned on
-	 * an 8-byte bounary, fill head/tail up to 28 bytes each.
-	 * As in the initial byte-based head/tail fill, each
-	 * conditional below ensures that the subsequent offsets
-	 * are valid (e.g. !(n<=24) implies n>=28). */
+    /* In preparation to copy 32 bytes at a time, aligned on
+     * an 8-byte bounary, fill head/tail up to 28 bytes each.
+     * As in the initial byte-based head/tail fill, each
+     * conditional below ensures that the subsequent offsets
+     * are valid (e.g. !(n<=24) implies n>=28). */
 
-	*(u32 *)(s+0) = c32;
-	*(u32 *)(s+n-4) = c32;
-	if (n <= 8) return dest;
-	*(u32 *)(s+4) = c32;
-	*(u32 *)(s+8) = c32;
-	*(u32 *)(s+n-12) = c32;
-	*(u32 *)(s+n-8) = c32;
-	if (n <= 24) return dest;
-	*(u32 *)(s+12) = c32;
-	*(u32 *)(s+16) = c32;
-	*(u32 *)(s+20) = c32;
-	*(u32 *)(s+24) = c32;
-	*(u32 *)(s+n-28) = c32;
-	*(u32 *)(s+n-24) = c32;
-	*(u32 *)(s+n-20) = c32;
-	*(u32 *)(s+n-16) = c32;
+    *(u32 *)(s + 0) = c32;
+    *(u32 *)(s + n - 4) = c32;
+    if (n <= 8) {
+        return dest;
+    }
+    *(u32 *)(s + 4) = c32;
+    *(u32 *)(s + 8) = c32;
+    *(u32 *)(s + n - 12) = c32;
+    *(u32 *)(s + n - 8) = c32;
+    if (n <= 24) {
+        return dest;
+    }
+    *(u32 *)(s + 12) = c32;
+    *(u32 *)(s + 16) = c32;
+    *(u32 *)(s + 20) = c32;
+    *(u32 *)(s + 24) = c32;
+    *(u32 *)(s + n - 28) = c32;
+    *(u32 *)(s + n - 24) = c32;
+    *(u32 *)(s + n - 20) = c32;
+    *(u32 *)(s + n - 16) = c32;
 
-	/* Align to a multiple of 8 so we can fill 64 bits at a time,
-	 * and avoid writing the same bytes twice as much as is
-	 * practical without introducing additional branching. */
+    /* Align to a multiple of 8 so we can fill 64 bits at a time,
+     * and avoid writing the same bytes twice as much as is
+     * practical without introducing additional branching. */
 
-	k = 24 + ((sel4runtime_uintptr_t)s & 4);
-	s += k;
-	n -= k;
+    k = 24 + ((sel4runtime_uintptr_t)s & 4);
+    s += k;
+    n -= k;
 
-	/* If this loop is reached, 28 tail bytes have already been
-	 * filled, so any remainder when n drops below 32 can be
-	 * safely ignored. */
+    /* If this loop is reached, 28 tail bytes have already been
+     * filled, so any remainder when n drops below 32 can be
+     * safely ignored. */
 
-	u64 c64 = c32 | ((u64)c32 << 32);
-	for (; n >= 32; n-=32, s+=32) {
-		*(u64 *)(s+0) = c64;
-		*(u64 *)(s+8) = c64;
-		*(u64 *)(s+16) = c64;
-		*(u64 *)(s+24) = c64;
-	}
+    u64 c64 = c32 | ((u64)c32 << 32);
+    for (; n >= 32; n -= 32, s += 32) {
+        *(u64 *)(s + 0) = c64;
+        *(u64 *)(s + 8) = c64;
+        *(u64 *)(s + 16) = c64;
+        *(u64 *)(s + 24) = c64;
+    }
 #else
-	/* Pure C fallback with no aliasing violations. */
-	for (; n; n--, s++) *s = c;
+    /* Pure C fallback with no aliasing violations. */
+    for (; n; n--, s++) {
+        *s = c;
+    }
 #endif
 
-	return dest;
+    return dest;
 }

--- a/src/start_root.c
+++ b/src/start_root.c
@@ -11,8 +11,8 @@
  */
 #include <sel4/sel4.h>
 #include <sel4runtime/start.h>
-#include <stdint.h>
-#include <stddef.h>
+#include <sel4runtime/stdint.h>
+#include <sel4runtime/stddef.h>
 
 /*
  * As this file is only included when we are running a root server,
@@ -41,9 +41,9 @@ long sel4_vsyscall(long sysnum, ...);
  */
 void __sel4_start_root(seL4_BootInfo *boot_info)
 {
-    uintptr_t tdata_start = (uintptr_t) &_tdata_start[0];
-    uintptr_t tdata_end = (uintptr_t) &_tdata_end[0];
-    uintptr_t tbss_end = (uintptr_t) &_tbss_end[0];
+    sel4runtime_uintptr_t tdata_start = (sel4runtime_uintptr_t) &_tdata_start[0];
+    sel4runtime_uintptr_t tdata_end = (sel4runtime_uintptr_t) &_tdata_end[0];
+    sel4runtime_uintptr_t tbss_end = (sel4runtime_uintptr_t) &_tbss_end[0];
 
     Elf_Phdr tls_header = {
         .p_type   = PT_TLS,
@@ -83,12 +83,12 @@ void __sel4_start_root(seL4_BootInfo *boot_info)
 
     char const *const envp[] = {
         "seL4=1",
-        NULL,
+        SEL4RUNTIME_NULL,
     };
 
     char const *const argv[] = {
         "rootserver",
-        NULL,
+        SEL4RUNTIME_NULL,
     };
 
     __sel4runtime_start_main(main, ARRAY_LENGTH(argv), argv, envp, auxv);

--- a/src/util.h
+++ b/src/util.h
@@ -9,8 +9,8 @@
  *
  * @TAG(DATA61_BSD)
  */
-#include <stddef.h>
-#include <stdint.h>
+#include <sel4runtime/stddef.h>
+#include <sel4runtime/stdint.h>
 
 #define ALIGN_UP(x, n) (((x) + (n) - 1) & ~((n) - 1))
 #define ALIGN_DOWN(x, n) ((x) & ~((n) - 1))
@@ -35,6 +35,6 @@
 void *__sel4runtime_memcpy(
     void *restrict dest,
     const void *restrict src,
-    size_t n
+    sel4runtime_size_t n
 );
-void *__sel4runtime_memset(void *dest, int c, size_t n);
+void *__sel4runtime_memset(void *dest, int c, sel4runtime_size_t n);

--- a/src/vsyscall.c
+++ b/src/vsyscall.c
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2020, Data61
+ * Commonwealth Scientific and Industrial Research Organisation (CSIRO)
+ * ABN 41 687 119 230.
+ *
+ * This software may be distributed and modified according to the terms of
+ * the BSD 2-Clause license. Note that NO WARRANTY is provided.
+ * See "LICENSE_BSD2.txt" for details.
+ *
+ * @TAG(DATA61_BSD)
+ */
+
+/* If no vsyscall implementation is provided, this dummy one is used. */
+long __sel4runtime_vsyscall(long sysnum, ...)
+{
+    return -1;
+}
+
+long __attribute__((weak, alias("__sel4runtime_vsyscall"))) sel4_vsyscall(long sysnum, ...);


### PR DESCRIPTION
In order to reduce the set of dependencies for `sel4runtime`, the small subset of the C standard library that is used has been duplicated inside of the runtime.

Additionally, the library used to integrate the standard library (`libsel4muslcsys`) is responsible for ensuring the virtual syscall handler is initialised by the C standard library provided.

Blocked by sel4/sel4_libs#21