### PR TITLE
start.c: Ensure that __init_libc is called

### DIFF
--- a/src/start.c
+++ b/src/start.c
@@ -21,6 +21,8 @@ void __sel4runtime_start_main(
     auxv_t const auxv[]
 )
 {
+    __init_libc(envp, argv[0]);
+
     __sel4runtime_load_env(argc, argv, envp, auxv);
 
     sel4runtime_exit(main(argc, argv, envp));


### PR DESCRIPTION
musl includes some constructors that are used to initalise global
variables. This is all setup from the __init_libc() function.

Currently __init_libc() and the constuctors are included in seL4 user
space apps, but are never called. This can result in crashes when code
tries to use malloc as the __sysinfo variable is never set.

This patch ensures that the __init_libc() function is called so that all
global variables are configured.

For more details on how the boot flow looks, see:
https://github.com/jhand2/openenclave/blob/36c8b9bc662bf575d0f21af43e24c9cf69bcc4fe/docs/DesignDocs/libc_initialization.md

Signed-off-by: Alistair Francis <alistair.francis@wdc.com>